### PR TITLE
Templates fixes for the next release of pagedown

### DIFF
--- a/inst/resources/css/style_grid.css
+++ b/inst/resources/css/style_grid.css
@@ -242,67 +242,68 @@ h1.title {
     @bottom-left {
       display: none;
     }
-    
+
     @bottom-right-corner{
       display: none;
     }
   }
 
 /* ------------------------ Back Cover ---------------------- */
-.pagedjs_page:last-of-type {
-    margin: 0 0 0 0;
+@page back-cover {
     background-color: var(--main-color);
     background-image: url(../utils/grid_white.png);
     background-repeat: no-repeat;
     background-position: 80% 10%;
     background-size: 20%;
-  }
 
-/* bottom */
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-bottom-right {
-    content: "";
-    margin-top: -70%;
-    margin-right: -50%;
-    margin-left: 60%;
-    margin-bottom: -40%;
-    color: #ffffff;
-    background-color: #ffffff;
-    border: none;
-  }
+    @bottom-right {
+        content: "";
+        margin-top: -70%;
+        margin-right: -50%;
+        margin-left: 60%;
+        margin-bottom: -40%;
+        color: #ffffff;
+        background-color: #ffffff;
+        border: none;
+    }
 
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-bottom-center {
-  content: "";
-  margin-top: -70%;
-  margin-right: -80%;
-  margin-left: -50%;
-  margin-bottom: -40%;
-  color: #ffffff;
-  background-color: #ffffff;
-  background-image: var(--back-cover) ;
-  background-repeat: no-repeat;
-  background-position: 80% 20%;
-  background-size: 2cm;
-  border: none;
+    @bottom-center {
+        content: "";
+        margin-top: -70%;
+        margin-right: -80%;
+        margin-left: -50%;
+        margin-bottom: -40%;
+        color: #ffffff;
+        background-color: #ffffff;
+        background-image: var(--back-cover) ;
+        background-repeat: no-repeat;
+        background-position: 80% 20%;
+        background-size: 2cm;
+        border: none;
+    }
+
+    @bottom-left {
+        content: "";
+        margin-top: -70%;
+        margin-left: -50%;
+        margin-right: 0%;
+        margin-bottom: -40%;
+        color: #ffffff;
+        background-color: #ffffff;
+        border: none;
+    }
+
+    @left-top {
+        display: none;
+    }
+
+    @right-top {
+        display: none;
+    }
 }
 
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-bottom-left {
-  content: "";
-  margin-top: -70%;
-  margin-left: -50%;
-  margin-right: 0%;
-  margin-bottom: -40%;
-  color: #ffffff;
-  background-color: #ffffff;
-  border: none;
-}
-
-/* remove grid */
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-left-top {
-  display: none;
-}
-
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-right-top {
-  display: none;
+.back-cover {
+  page: back-cover;
 }
 
 /* ------------------------ Fonts ---------------------------- */
@@ -362,7 +363,7 @@ h2 {
 /* --------------------- CSS Fragmentation --------------------------- */
 /* page breaks; aka CSS fragmentation */
 .level1 {
-    page: chapter;
+    break-before: page;
   }
 
   .section > h1, .section > h2, .section > h3, .section > h4, .section > h5, .section > h6 {

--- a/inst/resources/css/style_hazelnuts.css
+++ b/inst/resources/css/style_hazelnuts.css
@@ -93,7 +93,7 @@ h1.title {
       content: string(h1-title) " | ";
       font-family: var(--header-font);
       text-align: right;
-      margin-right: -15cm;
+      margin-right: -3cm;
       color: var(--main-color);
     }
 
@@ -112,7 +112,7 @@ h1.title {
     @top-center {
       content: " | " string(h1-text);
       font-family: var(--header-font);
-      margin-left: 1cm;
+      margin-left: -11cm;
       color: var(--main-color);
     }
 

--- a/inst/resources/css/style_hazelnuts.css
+++ b/inst/resources/css/style_hazelnuts.css
@@ -16,7 +16,7 @@
     --main-font: "Gelasio";
     --header-font: "Inter";
   }
-  
+
 /* ---------------------- For debugging -------------------- */
 /* two pages in a row if possible on screen */
 @media screen {
@@ -136,29 +136,28 @@ h1.title {
 
 /* ------------------------ Front Cover --------------------- */
 @page:first{
-    margin: 0 0 0 0;
     background-color: #ffffff;
     background-image: url(../utils/line.svg), url(../utils/line.svg), var(--front-cover), var(--front-cover-2);
     background-repeat: no-repeat, no-repeat, no-repeat, no-repeat;
     background-position: 5% 40%, 95% 40%, 4cm 24cm, 0cm 0cm ;
-    background-size:  5cm, 5cm, 3cm, cover;  
+    background-size:  5cm, 5cm, 3cm, cover;
 
     @top-left-corner {
       display: none;
     }
-  
+
     @top-left {
       display: none;
     }
-    
+
     @top-center {
       display: none;
     }
-  
+
     @top-right {
       display: none;
     }
-  
+
     @top-right-corner {
       display: none;
     }
@@ -173,28 +172,17 @@ h1.title {
   }
 
 /* ------------------------ Back Cover ---------------------- */
-.pagedjs_page:last-of-type {
+@page back-cover {
     margin: 0 0 0 0;
     background-image: var(--back-cover), var(--back-cover-2);
     background-repeat: no-repeat, no-repeat;
     background-position: 15cm 23cm, 0cm 0cm;
     background-size: 3cm, cover;
-  }
+}
 
-/* avoiding counter to be printed */
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-top-right {
-    display: none;
-  }
-
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-top-center {
-    display: none;
-  }
-
-
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-top-left {
-    display: none;
-  }
-
+.back-cover {
+  page: back-cover;
+}
 
 /* ----------------------- Table of contents ----------------------- */
 .toc a {
@@ -282,7 +270,7 @@ h1, h2, h3, h4 {
 
 /* ------------------------ Style ----------------------------- */
 /* colors */
-h2, h3, h4 { 
+h2, h3, h4 {
     color: var(--secondary-color)
 }
 
@@ -339,7 +327,7 @@ h1 {
   background-image: url(../utils/line.svg), url(../utils/line.svg);
   background-repeat: no-repeat, no-repeat;
   background-position: 5% 40%, 95% 40%;
-  background-size:  5cm, 5cm;  
+  background-size:  5cm, 5cm;
   margin-right: -17%;
   margin-left: -17%;
   margin-top: -10%;
@@ -352,9 +340,9 @@ h2 {
 /* --------------------- CSS Fragmentation --------------------------- */
 /* page breaks; aka CSS fragmentation */
 .level1 {
-    page: chapter;
+    break-before: page;
   }
-  
+
 .section > h1, .section > h2, .section > h3, .section > h4, .section > h5, .section > h6 {
   break-after: avoid;
 }
@@ -379,4 +367,3 @@ caption {
 img {
   max-width: 100%;
 }
-  

--- a/inst/resources/css/style_windmill.css
+++ b/inst/resources/css/style_windmill.css
@@ -141,7 +141,6 @@ h1.title {
 
 /* ------------------------ Front Cover --------------------- */
 @page:first{
-    margin: 0 0 0 0;
     background-color: #ffffff;
     background-image: var(--front-cover), var(--front-cover-2);
     background-repeat: no-repeat, no-repeat;
@@ -178,19 +177,18 @@ h1.title {
   }
 
 /* ------------------------ Back Cover ---------------------- */
-.pagedjs_page:last-of-type {
+@page back-cover {
     margin: 0 0 0 0;
     background-color: var(--main-color);
     background-image: var(--back-cover);
     background-repeat: no-repeat;
     background-position: 15cm 23cm;
     background-size: 4cm;
-  }
+}
 
-/* avoiding counter to be printed */
-.pagedjs_page:last-of-type .pagedjs_margin.pagedjs_margin-bottom-right {
-    display: none;
-  }
+.back-cover {
+  page: back-cover;
+}
 
 /* ------------------------ Fonts ---------------------------- */
 @import 'https://fonts.googleapis.com/css?family=Gelasio';
@@ -252,7 +250,7 @@ p, ul {
 /* --------------------- CSS Fragmentation --------------------------- */
 /* page breaks; aka CSS fragmentation */
 .level1 {
-    page: chapter;
+    break-before: page;
   }
 
   .section > h1, .section > h2, .section > h3, .section > h4, .section > h5, .section > h6 {
@@ -279,3 +277,4 @@ p, ul {
   img {
     max-width: 100%;
   }
+

--- a/inst/resources/html/template_paged.html
+++ b/inst/resources/html/template_paged.html
@@ -279,6 +279,9 @@ $endif$
 $body$
 </div>
 
+<div class="back-cover">
+</div>
+
 $for(include-after)$
 $include-after$
 $endfor$


### PR DESCRIPTION
The goal of this PR is to fix #22.

In the next **pagedown** release, Paged.js is upgraded from version 0.1.32 to 0.1.43.
This update fixes several bugs in Paged.js.  
These bugfixes impact **pagedreport** templates because they exploit some of the underlying bugs :upside_down_face: 

### The zero margins bug

With **pagedown** <= 0.13, the following rule has been ignored:

``` css
@page {
    margin: 0 0 0 0;
}
```

With **pagedown** >= 0.13.2, this bug is now fixed. 
Despite this rule has no effect, it appears in each of **pagedreport** templates. 
So, the Paged.js bug fix will break the **pagedreport** templates.

It is quite easy to solve this problem: one has to remove this rule (done through this PR).

### The extra blank pages bug

Paged.js has had a longstanding bug: it has generated some extra blank pages, particularly the last page.
The back cover of **pagedreport** templates exploit this bug. 
So, the next version of **pagedown** will remove these back covers.

This PR proposes to introduce a `div` element of class `back-cover` in the HTML template to rely on **pagedown** covers feature (see <https://pagedown.rbind.io/#covers>). A named page is then used for the back cover.

**A side effect of this bug fix** is that the extra blank page after the table of contents of the `hazelnut` template disappears.
_Please, let me know if you prefer to keep this blank page, I'll update this PR._

### The `page` property bug

The CSS stylesheets of **pagereport** have this declaration:

``` css
.level1 {
    page: chapter;
}
```

But the `chapter` named page is not defined in the remaining parts of these stylesheets.

In its previous versions, Paged.js introduced a page break when a `page` property was used. It was a bug that is now fixed.

This PR proposes to keep the same behavior by using:

``` css
.level1 {
    break-before: page;
}
```

### PDF generated with this PR

Here are the PDF that one can generate with this PR. As mentioned earlier, the remaining difference I've noticed is the extra blank page after the table of contents. Let me know if you detect some other differences.

| **pagedown** 0.13 (CRAN version)  | **pagedown** 0.13.8 (dev version) |
| ------------- | ------------- |
| [grid_fixed-pagedown_0.13.pdf](https://github.com/rfortherestofus/pagedreport/files/5839239/grid_fixed-pagedown_0.13.pdf) | [grid_fixed-pagedown_0.13.8.pdf](https://github.com/rfortherestofus/pagedreport/files/5839290/grid_fixed-pagedown_0.13.8.pdf)  |
| [hazelnuts_fixed-pagedown_0.13.pdf](https://github.com/rfortherestofus/pagedreport/files/5839242/hazelnuts_fixed-pagedown_0.13.pdf)  | [hazelnuts_fixed-pagedown_0.13.8.pdf](https://github.com/rfortherestofus/pagedreport/files/5839291/hazelnuts_fixed-pagedown_0.13.8.pdf)  |
| [windmill_fixed-pagedown_0.13.pdf](https://github.com/rfortherestofus/pagedreport/files/5839245/windmill_fixed-pagedown_0.13.pdf)  | [windmill_fixed-pagedown_0.13.8.pdf](https://github.com/rfortherestofus/pagedreport/files/5839293/windmill_fixed-pagedown_0.13.8.pdf)  |
